### PR TITLE
Modifica formato dos campos de impostos do model Servico

### DIFF
--- a/lib/enotas_nfe/model/servico.rb
+++ b/lib/enotas_nfe/model/servico.rb
@@ -13,11 +13,11 @@ module EnotasNfe
       attribute :itemListaServicoLC116, String
       attribute :ufPrestacaoServico, String
       attribute :municipioPrestacaoServico, String
-      attribute :valorCofins, Decimal
-      attribute :valorInss, Decimal
-      attribute :valorIr, Decimal
-      attribute :valorPis, Decimal
-      attribute :valorCsll, Decimal
+      attribute :valorCofins, Float
+      attribute :valorInss, Float
+      attribute :valorIr, Float
+      attribute :valorPis, Float
+      attribute :valorCsll, Float
 
     end
   end


### PR DESCRIPTION
Estes campos estão sendo enviados como `string` no json, e isso causa problemas na API do E-Notas. Por algum motivo, o parser transforma decimal em `string`, por isso, troquei para Float o tipo desses campos. 

![image](https://user-images.githubusercontent.com/2729095/35743135-be53b5a0-0823-11e8-9c5e-e2e02ffcaae0.png)
