### PR TITLE
Incrementa versão mínima do faraday e substitui método depreciado

### DIFF
--- a/enotas_nfe.gemspec
+++ b/enotas_nfe.gemspec
@@ -21,11 +21,11 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "bundler", "~> 2.2"
-  s.add_development_dependency 'rake', '~> 12.3'
+  s.add_development_dependency "rake", "~> 12.3"
   s.add_development_dependency "rspec", "~> 3.0"
 
   s.add_runtime_dependency "virtus", '~> 1.0', '>= 1.0.5'
   s.add_runtime_dependency "virtus_convert", "~> 0.1.0"
-  s.add_runtime_dependency "faraday", "~> 0.9"
-  s.add_runtime_dependency "faraday_middleware", "~> 0.12.0"
+  s.add_runtime_dependency "faraday", "~> 1.0"
+  s.add_runtime_dependency "faraday_middleware", "~> 1.0"
 end

--- a/lib/enotas_nfe/request.rb
+++ b/lib/enotas_nfe/request.rb
@@ -38,6 +38,8 @@ module EnotasNfe
       body_serialized = serialize_body(body)
 
       response = connection.send(method) do |request|
+        path = ERB::Util.url_encode(path)
+
         case method
         when :get, :delete
           request.url(path, body_serialized)

--- a/lib/enotas_nfe/request.rb
+++ b/lib/enotas_nfe/request.rb
@@ -38,8 +38,6 @@ module EnotasNfe
       body_serialized = serialize_body(body)
 
       response = connection.send(method) do |request|
-        path = URI.encode(path)
-
         case method
         when :get, :delete
           request.url(path, body_serialized)

--- a/lib/enotas_nfe/request.rb
+++ b/lib/enotas_nfe/request.rb
@@ -38,7 +38,7 @@ module EnotasNfe
       body_serialized = serialize_body(body)
 
       response = connection.send(method) do |request|
-        path = ERB::Util.url_encode(path)
+        path = URI::DEFAULT_PARSER.escape(path)
 
         case method
         when :get, :delete

--- a/lib/enotas_nfe/version.rb
+++ b/lib/enotas_nfe/version.rb
@@ -1,3 +1,3 @@
 module EnotasNfe
-  VERSION = "0.0.34"
+  VERSION = "0.0.35"
 end


### PR DESCRIPTION
- `URI.encode` já foi depreciado a alguns anos, mas no Ruby 2.7 passou a exibir o warning, substituído pelo `URI::DEFAULT_PARSER.escape` para manter o mesmo comportamento.
- Incrementada a versão mínima do faraday pois a 0.9 também fazia o uso de `URI.encode`.

Já atualizei a versão da gem para `0.35`