### PR TITLE
Remove log de Request e Response que tinha sido adicionado para debugar um problema

### DIFF
--- a/enotas_nfe.gemspec
+++ b/enotas_nfe.gemspec
@@ -28,5 +28,4 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "virtus_convert", "~> 0.1.0"
   s.add_runtime_dependency "faraday", "~> 1.0"
   s.add_runtime_dependency "faraday_middleware", "~> 1.0"
-  s.add_runtime_dependency "faraday-detailed_logger"
 end

--- a/enotas_nfe.gemspec
+++ b/enotas_nfe.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "virtus_convert", "~> 0.1.0"
   s.add_runtime_dependency "faraday", "~> 1.0"
   s.add_runtime_dependency "faraday_middleware", "~> 1.0"
+  s.add_runtime_dependency "faraday-detailed_logger"
 end

--- a/lib/enotas_nfe/connection.rb
+++ b/lib/enotas_nfe/connection.rb
@@ -1,5 +1,4 @@
 require 'faraday_middleware'
-require 'faraday/detailed_logger'
 
 module EnotasNfe
   module Connection
@@ -22,7 +21,6 @@ module EnotasNfe
 
         connection.request :multipart
         connection.adapter :net_http
-        connection.response :detailed_logger, EnotasNfe.logger, "ENotasNfe: "
       end
     end
   end

--- a/lib/enotas_nfe/connection.rb
+++ b/lib/enotas_nfe/connection.rb
@@ -1,4 +1,5 @@
 require 'faraday_middleware'
+require 'faraday/detailed_logger'
 
 module EnotasNfe
   module Connection
@@ -21,6 +22,7 @@ module EnotasNfe
 
         connection.request :multipart
         connection.adapter :net_http
+        connection.response :detailed_logger, EnotasNfe.logger, "ENotasNfe: "
       end
     end
   end


### PR DESCRIPTION
Essa alteração tinha sido adicionada a pouco tempo para logar os dados de requisição e resposta para passarmos pro suporte do eNotas para verificarem um problema que estava acontecendo, mas vou remover essas alterações porque não estamos mais utilizando no monde-web https://github.com/monde-sistemas/monde-web/pull/3599