### PR TITLE
Novos atributos e modelo para emissão via NFS-e Nacional

### DIFF
--- a/lib/enotas_nfe.rb
+++ b/lib/enotas_nfe.rb
@@ -46,6 +46,7 @@ require "enotas_nfe/model/issqn"
 require "enotas_nfe/model/pis"
 require "enotas_nfe/model/metadados"
 require "enotas_nfe/model/cidade_prestacao"
+require "enotas_nfe/model/percentual_tributos_federal"
 require "enotas_nfe/facades"
 require "enotas_nfe/client"
 

--- a/lib/enotas_nfe/model/empresa.rb
+++ b/lib/enotas_nfe/model/empresa.rb
@@ -7,6 +7,7 @@ module EnotasNfe
       require "enotas_nfe/model/configuracoes_nfse_homologacao"
       require "enotas_nfe/model/configuracoes_nfse_producao"
       require "enotas_nfe/model/emissao_nfe_consumidor"
+      require "enotas_nfe/model/metadados"
       require 'open-uri'
 
       include Virtus.model
@@ -39,6 +40,7 @@ module EnotasNfe
       attribute :configuracoesNFSeHomologacao, ConfiguracoesNFSeHomologacao
       attribute :configuracoesNFSeProducao, ConfiguracoesNFSeProducao
       attribute :mei, Boolean
+      attribute :metadados, Metadados
     end
   end
 end

--- a/lib/enotas_nfe/model/metadados.rb
+++ b/lib/enotas_nfe/model/metadados.rb
@@ -4,10 +4,12 @@ module EnotasNfe
 
       include Virtus.model
       require "enotas_nfe/model/cidade_prestacao"
+      require "enotas_nfe/model/percentual_tributos_federal"
 
       attribute :cidadeprestacao, CidadePrestacao
       attribute :valorTotalRecebido, Float
       attribute :regimeApuracaoTributosSN, String
+      attribute :valorPercentualTributosFederal, PercentualTributosFederal
     end
   end
 end

--- a/lib/enotas_nfe/model/metadados.rb
+++ b/lib/enotas_nfe/model/metadados.rb
@@ -7,6 +7,7 @@ module EnotasNfe
 
       attribute :cidadeprestacao, CidadePrestacao
       attribute :valorTotalRecebido, Float
+      attribute :regimeApuracaoTributosSN, String
     end
   end
 end

--- a/lib/enotas_nfe/model/percentual_tributos_federal.rb
+++ b/lib/enotas_nfe/model/percentual_tributos_federal.rb
@@ -1,0 +1,13 @@
+module EnotasNfe
+  module Model
+    class PercentualTributosFederal
+
+      include Virtus.model
+
+      attribute :PercentualTotalFederal, Integer
+      attribute :PercentualTotalEstadual, Integer
+      attribute :PercentualTotalMunicipal, Integer
+    end
+  end
+end
+  

--- a/lib/enotas_nfe/version.rb
+++ b/lib/enotas_nfe/version.rb
@@ -1,3 +1,3 @@
 module EnotasNfe
-  VERSION = "0.0.37"
+  VERSION = "0.0.38"
 end

--- a/lib/enotas_nfe/version.rb
+++ b/lib/enotas_nfe/version.rb
@@ -1,3 +1,3 @@
 module EnotasNfe
-  VERSION = "0.0.38"
+  VERSION = "0.0.39"
 end


### PR DESCRIPTION
Como parte da adequação do eNotas para emissão via NFS-e Nacional, surgiu a necessidade de adicionar novos atributos e modelos na gem. É possível ver mais informações no artigo do eNotas:
[Tudo que você precisa saber para emitir NFS-e no modelo Nacional no eNotas Gateway](https://atendimento.enotas.com.br/kb/article/408298).