### PR TITLE
Adiciona novos atributos necessários na emissão de NFS-e para tomador do exterior

### DIFF
--- a/lib/enotas_nfe.rb
+++ b/lib/enotas_nfe.rb
@@ -48,6 +48,7 @@ require "enotas_nfe/model/metadados"
 require "enotas_nfe/model/dados_adicionais_email"
 require "enotas_nfe/model/cidade_prestacao"
 require "enotas_nfe/model/percentual_tributos_federal"
+require "enotas_nfe/model/info_comercio_exterior"
 require "enotas_nfe/facades"
 require "enotas_nfe/client"
 

--- a/lib/enotas_nfe/model/info_comercio_exterior.rb
+++ b/lib/enotas_nfe/model/info_comercio_exterior.rb
@@ -1,0 +1,18 @@
+module EnotasNfe
+  module Model
+    class InfoComercioExterior
+
+      include Virtus.model
+
+      attribute :modoPrestacao, Integer
+      attribute :vinculoPrestacao, Integer
+      attribute :tipoMoeda, Integer
+      attribute :valorServicoMoedaEstrangeira, Integer
+      attribute :mecanismoApoioPrestador, Integer
+      attribute :mecanismoApoioTomador, Integer
+      attribute :movimentacaoTemporariaBens, Integer
+      attribute :compartilharComMDIC, Integer
+      attribute :codigoNBSCorrespondenteaoServicoPrestado, String
+    end
+  end
+end

--- a/lib/enotas_nfe/model/metadados.rb
+++ b/lib/enotas_nfe/model/metadados.rb
@@ -5,11 +5,13 @@ module EnotasNfe
       include Virtus.model
       require "enotas_nfe/model/cidade_prestacao"
       require "enotas_nfe/model/percentual_tributos_federal"
+      require "enotas_nfe/model/info_comercio_exterior"
 
       attribute :cidadeprestacao, CidadePrestacao
       attribute :valorTotalRecebido, Float
       attribute :regimeApuracaoTributosSN, String
       attribute :valorPercentualTributosFederal, PercentualTributosFederal
+      attribute :InfoComercioExterior, InfoComercioExterior
     end
   end
 end

--- a/lib/enotas_nfe/version.rb
+++ b/lib/enotas_nfe/version.rb
@@ -1,3 +1,3 @@
 module EnotasNfe
-  VERSION = "0.0.40"
+  VERSION = "0.0.41"
 end


### PR DESCRIPTION
Conforme a seção `Emissão de NFS-e para tomador do exterior` do artigo [Tudo que você precisa saber para emitir NFS-e no modelo Nacional no eNotas Gateway](https://atendimento.enotas.com.br/kb/article/408298), é necessário informar alguns campos.
 Estou adicionando o modelo `InfoComercioExterior` com os atributos necessários.